### PR TITLE
1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-parser",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "A standalone implementation of angular's expression parser",
   "main": "src/parser.js",
   "scripts": {


### PR DESCRIPTION
fix(semver): bumped the version to major.

The best practice for node modules that are shared with others is to start with the version 1.0.0
This way the module consumer can choose whether he'd like to get patch/minor or major updates.

When the major version is 0 the consumer can't choose to get minor updates (eg. 0.3.0)

You can read more about it here:
https://docs.npmjs.com/getting-started/semantic-versioning
https://docs.npmjs.com/misc/semver
